### PR TITLE
Add collision tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,5 +5,7 @@
 	 com.badlogicgames.gdx/gdx-backend-lwjgl3 {:mvn/version "1.11.0"}
 	 com.badlogicgames.gdx/gdx-platform$natives-desktop {:mvn/version "1.11.0"}}
   :aliases {:run-game {:jvm-opts ["-XstartOnFirstThread"]
-		       :main-opts ["-m" "catcafe.desktop-launcher"]}}
- }
+                       :main-opts ["-m" "catcafe.desktop-launcher"]}
+            :test {:extra-paths ["test"]
+                   :exec-fn catcafe.test-runner/run}}
+}

--- a/test/catcafe/core_test.clj
+++ b/test/catcafe/core_test.clj
@@ -1,0 +1,12 @@
+(ns catcafe.core-test
+  (:require [clojure.test :refer :all]
+            [catcafe.core :refer [check-collision]]))
+
+(deftest overlapping-rectangles
+  (testing "Rectangles that overlap should collide"
+    (is (true? (check-collision 0 0 50 50 25 25 50 50)))))
+
+(deftest non-overlapping-rectangles
+  (testing "Rectangles that do not overlap should not collide"
+    (is (false? (check-collision 0 0 10 10 20 20 5 5)))))
+

--- a/test/catcafe/test_runner.clj
+++ b/test/catcafe/test_runner.clj
@@ -1,0 +1,8 @@
+(ns catcafe.test-runner
+  (:require [clojure.test :as t]
+            catcafe.core-test))
+
+(defn run
+  "Run all tests." [_]
+  (t/run-tests 'catcafe.core-test))
+


### PR DESCRIPTION
## Summary
- add unit tests for collision detection
- provide a simple test runner
- allow running tests via `clj -X:test`

## Testing
- `clj -X:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3d75a6bc832cbf2235554102ba40