### PR TITLE
Introduce basic ECS framework

### DIFF
--- a/src/catcafe/components.clj
+++ b/src/catcafe/components.clj
@@ -1,0 +1,22 @@
+(ns catcafe.components)
+
+(defrecord Position [x y])
+(defrecord Velocity [dx dy])
+(defrecord Sprite [standing-right standing-left width height])
+(defrecord Animation [walk-right walk-left time])
+(defrecord Input [left? right? up? down?])
+
+(defn position [x y]
+  (->Position x y))
+
+(defn velocity [dx dy]
+  (->Velocity dx dy))
+
+(defn sprite [standing-right standing-left width height]
+  (->Sprite standing-right standing-left width height))
+
+(defn animation [walk-right walk-left]
+  (->Animation walk-right walk-left 0))
+
+(defn input []
+  (->Input false false false false))

--- a/src/catcafe/entity.clj
+++ b/src/catcafe/entity.clj
@@ -1,0 +1,21 @@
+(ns catcafe.entity)
+
+(defonce registry (atom {}))
+(defonce next-id (atom 0))
+
+(defn create-entity
+  "Add a new entity with the given components map to the registry and return its id."
+  [components]
+  (let [id (swap! next-id inc)]
+    (swap! registry assoc id components)
+    id))
+
+(defn destroy-entity
+  "Remove an entity from the registry."
+  [id]
+  (swap! registry dissoc id))
+
+(defn update-entity
+  "Update an entity using fn f and optional args."
+  [id f & args]
+  (apply swap! registry update id f args))

--- a/src/catcafe/factories.clj
+++ b/src/catcafe/factories.clj
@@ -1,0 +1,43 @@
+(ns catcafe.factories
+  (:require [catcafe.entity :as e]
+            [catcafe.components :as c]
+            [catcafe.core :refer [create-walking-animation-right
+                                   create-walking-animation-left
+                                   player-visual-width
+                                   player-visual-height]])
+  (:import (com.badlogic.gdx.graphics Texture Sprite)))
+
+(defn create-player
+  []
+  (let [standing-texture (Texture. "images/ysabelWalkingRight1.png")
+        standing-right (doto (Sprite. standing-texture)
+                         (.setSize player-visual-width player-visual-height))
+        standing-left (doto (Sprite. standing-texture)
+                        (.setSize player-visual-width player-visual-height)
+                        (.flip true false))
+        walk-right (create-walking-animation-right)
+        walk-left (create-walking-animation-left)]
+    (e/create-entity
+      {:position (c/position 400 100)
+       :velocity (c/velocity 0 0)
+       :sprite (c/sprite standing-right standing-left
+                         player-visual-width player-visual-height)
+       :animation (c/animation walk-right walk-left)
+       :input (c/input)})))
+
+(defn create-npc
+  []
+  (let [standing-texture (Texture. "images/maiaWalkingRight1.png")
+        standing-right (doto (Sprite. standing-texture)
+                         (.setSize player-visual-width player-visual-height))
+        standing-left (doto (Sprite. standing-texture)
+                        (.setSize player-visual-width player-visual-height)
+                        (.flip true false))
+        walk-right (catcafe.core/create-maia-walking-animation-right)
+        walk-left (catcafe.core/create-maia-walking-animation-left)]
+    (e/create-entity
+      {:position (c/position 200 100)
+       :velocity (c/velocity 0 0)
+       :sprite (c/sprite standing-right standing-left
+                         player-visual-width player-visual-height)
+       :animation (c/animation walk-right walk-left)})))

--- a/src/catcafe/systems.clj
+++ b/src/catcafe/systems.clj
@@ -1,0 +1,57 @@
+(ns catcafe.systems
+  (:require [catcafe.entity :as e]
+            [catcafe.components :as c]
+            [clojure.set :as set])
+  (:import (com.badlogic.gdx Gdx)
+           (com.badlogic.gdx Input$Keys)))
+
+(defn input-system
+  [delta]
+  (doseq [[id entity] @e/registry]
+    (when-let [input (:input entity)]
+      (let [left? (.isKeyPressed Gdx/input Input$Keys/LEFT)
+            right? (.isKeyPressed Gdx/input Input$Keys/RIGHT)
+            up? (.isKeyPressed Gdx/input Input$Keys/UP)
+            down? (.isKeyPressed Gdx/input Input$Keys/DOWN)
+            speed catcafe.core/player-speed
+            vx (cond left? (- speed) right? speed :else 0)
+            vy (cond down? (- speed) up? speed :else 0)]
+        (e/update-entity id assoc
+                         :input (assoc input :left? left? :right? right? :up? up? :down? down?)
+                         :velocity (c/velocity vx vy))))))
+
+(defn movement-system
+  [delta]
+  (doseq [[id entity] @e/registry]
+    (when-let [pos (:position entity)]
+      (let [vel (:velocity entity)
+            dx (* (:dx vel) delta)
+            dy (* (:dy vel) delta)
+            new-x (+ (:x pos) dx)
+            new-y (+ (:y pos) dy)
+            new-x (-> new-x (max catcafe.core/floor-x-min) (min catcafe.core/floor-x-max))
+            new-y (-> new-y (max catcafe.core/floor-y-min) (min catcafe.core/floor-y-max))
+            new-pos (c/position new-x new-y)]
+        (e/update-entity id assoc :position new-pos)))))
+
+(defn animation-system
+  [delta]
+  (doseq [[id entity] @e/registry]
+    (when-let [anim (:animation entity)]
+      (e/update-entity id update-in [:animation :time] + delta))))
+
+(defn npc-behavior-system
+  [delta]
+  ;; Placeholder for NPC behavior
+  )
+
+(defn render-system
+  [batch]
+  (doseq [[_ {:keys [position sprite animation input]}] @e/registry]
+    (when (and position sprite)
+      (let [{:keys [x y]} position
+            {:keys [standing-right standing-left width height]} sprite
+            facing-right? (if input (not (:left? input)) true)
+            current-standing (if facing-right? standing-right standing-left)]
+        (.setPosition current-standing (float x) (float y))
+        (.draw current-standing batch)))))

--- a/test/catcafe/core_test.clj
+++ b/test/catcafe/core_test.clj
@@ -4,9 +4,11 @@
 
 (deftest overlapping-rectangles
   (testing "Rectangles that overlap should collide"
-    (is (true? (check-collision 0 0 50 50 25 25 50 50)))))
+    (is (true? (check-collision {:x 0 :y 0 :width 50 :height 50}
+                                {:x 25 :y 25 :width 50 :height 50})))))
 
 (deftest non-overlapping-rectangles
   (testing "Rectangles that do not overlap should not collide"
-    (is (false? (check-collision 0 0 10 10 20 20 5 5)))))
+    (is (false? (check-collision {:x 0 :y 0 :width 10 :height 10}
+                                 {:x 20 :y 20 :width 5 :height 5})))))
 

--- a/test/catcafe/systems_test.clj
+++ b/test/catcafe/systems_test.clj
@@ -1,0 +1,20 @@
+(ns catcafe.systems-test
+  (:require [clojure.test :refer :all]
+            [catcafe.systems :as systems]
+            [catcafe.entity :as entity]
+            [catcafe.components :as c]))
+
+(deftest movement-updates-position
+  (reset! entity/registry {})
+  (reset! entity/next-id 0)
+  (let [id (entity/create-entity {:position (c/position 0 0)
+                                  :velocity (c/velocity 10 0)})]
+    (systems/movement-system 1.0)
+    (is (= 10 (:x (:position (@entity/registry id)))))))
+
+(deftest animation-increments-time
+  (reset! entity/registry {})
+  (reset! entity/next-id 0)
+  (let [id (entity/create-entity {:animation (c/animation nil nil)})]
+    (systems/animation-system 0.5)
+    (is (= 0.5 (-> (@entity/registry id) :animation :time)))))

--- a/test/catcafe/test_runner.clj
+++ b/test/catcafe/test_runner.clj
@@ -1,8 +1,9 @@
 (ns catcafe.test-runner
   (:require [clojure.test :as t]
-            catcafe.core-test))
+            catcafe.core-test
+            catcafe.systems-test))
 
 (defn run
   "Run all tests." [_]
-  (t/run-tests 'catcafe.core-test))
+  (t/run-tests 'catcafe.core-test 'catcafe.systems-test))
 


### PR DESCRIPTION
## Summary
- add `catcafe.entity` with a simple registry
- add component records such as `Position`, `Velocity` and `Sprite`
- create factories for player and npc
- implement system functions for input, movement, animation and rendering
- convert player update/render logic to use ECS
- refactor collision check to accept component maps
- add basic unit tests for movement and animation systems

## Testing
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed333df50832c9c055cfc3aff7738